### PR TITLE
Avoid ArduinoJSON Library NoMemory Errors

### DIFF
--- a/epaperdisplay/epaperdisplay.ino
+++ b/epaperdisplay/epaperdisplay.ino
@@ -37,8 +37,8 @@ HARestAPI ha(sclient);
 const char* ssid = "YOURWIFISSID";
 const char* password = "YOURWIFIPASSWORD";
 /* Put StaticIP Address details */
-IPAddress local_ip(192.168.1.1); // Set static IP
-IPAddress gateway(192.168.1.1); // Set network Gateway IP
+IPAddress local_ip(192,168,1,1); // Set static IP
+IPAddress gateway(192,168,1,1); // Set network Gateway IP
 IPAddress subnet(255, 255, 255, 0); // Set static IP
 IPAddress primaryDNS(8, 8, 8, 8);   //optional
 IPAddress secondaryDNS(8, 8, 4, 4); //optional
@@ -169,7 +169,10 @@ void ParseTimeJsonData(String strInput) {
 }
 float ParseSensorJsonData(String strInput) {
   TRACE(strInput);
-  DeserializationError error = deserializeJson(doc, strInput);
+  int strLen = strInput.length() + 1;
+  char charInput[strLen];
+  strInput.toCharArray(charInput, strLen);
+  DeserializationError error = deserializeJson(doc, charInput);
   if (error) {
     Serial.print(F("deserializeJson() failed: "));
     Serial.println(error.f_str());


### PR DESCRIPTION
In some cases sensors can send a long status json string, which causes NoMemory errors with ArduinoJSON Library. Better solution suggested by ArduinoJSON troubleshooter (here) is to provide it with a *char. Best would be using a stream. *char solves the issue well enough.

![image](https://user-images.githubusercontent.com/9054080/224070939-33dc86cb-f10b-4689-8a87-fa6849f9fc65.png)
